### PR TITLE
Grtwje alpha 4 prep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "se_monitoring_server_api"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 description = "Library for accessing the SolarEdge Monitoring Server API"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -49,5 +49,5 @@ To include the latest stable release, add this to your Cargo.toml file. (If ther
 
 ```toml
 [dependencies]
-se_monitoring_server_api = {git = "https://github.com/grtwje/se_ms_api", tag = "0.1.0-alpha.3"}
+se_monitoring_server_api = {git = "https://github.com/grtwje/se_ms_api", tag = "0.1.0-alpha.4"}
 ```


### PR DESCRIPTION
alpha.4 release

Made references to US states optional.
Fixed clippy warnings generated by new version of Rust tools. 